### PR TITLE
feature: Add setup command for Linux and OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,26 @@ Make sure you have `$GOPATH/bin` in your path. `export PATH=$PATH:$GOPATH/bin`
 
 Ergo looks for a `.ergo` file inside the current folder. It must contain the names and URL of the services following the same format as the `/etc/hosts` (domain+space+url) the main difference is that it also considers the port specified.
 
-**Set the `http://127.0.0.1:2000/proxy.pac` configuration on your system network config (Details below)**
-
 Let's start:
+
+#### Simplest Setup
+
+**You need to set the `http://127.0.0.1:2000/proxy.pac` configuration on your system network config.
+
+Ergo comes with a setup command that can configure the proxy for you. The current
+systems supporteds are:
+ - osx
+ - linux-gnome
+
+(Contributions are welcomed)
+
+```bash
+ergo setup <operation-system>
+```
+
+In case of errors or it doesn't work please take a look on detailed config session below.
+
+
 ```
 echo "ergoproxy http://localhost:3000" > .ergo
 ergo run
@@ -105,6 +122,11 @@ $ google-chrome --proxy-pac-url=http://localhost:2000/proxy.pac
 # OS X
 $ open -a "Google Chrome" --args --proxy-pac-url=http://localhost:2000/proxy.pac
 ```
+
+##### Ephemeral Setup
+
+As an alternative you can see the scripts inside `/resources` for running an
+ephemeral setup. Those scripts sets the proxy only while `ergo` is running.
 
 # License
 

--- a/commands/setup.go
+++ b/commands/setup.go
@@ -1,0 +1,68 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/cristianoliveira/ergo/proxy"
+	"log"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func Setup(system string, remove bool, config *proxy.Config) {
+	fmt.Println("Current detected system: " + runtime.GOOS)
+	proxy_url := "http://127.0.0.1:" + config.Port + "/proxy.pac"
+	script := ""
+	cmd := exec.Command("/bin/sh")
+
+	switch system {
+	case "linux-gnome":
+		if remove {
+			script = `
+				gsettings set org.gnome.system.proxy mode 'none'
+				gsettings set org.gnome.system.proxy autoconfig-url ''`
+
+		} else {
+			script = `
+				gsettings set org.gnome.system.proxy mode 'auto'
+				gsettings set org.gnome.system.proxy autoconfig-url '` + proxy_url + `'`
+
+			fmt.Println(`To configure the proxy on your terminal execute:
+			export http_proxy=http://127.0.0.1:` + config.Port)
+		}
+
+		cmd.Stdin = strings.NewReader(script)
+		err := cmd.Run()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+	case "osx":
+		if remove {
+			script = `sudo networksetup -setautoproxyurl "Wi-Fi" ""`
+		} else {
+			script = `sudo networksetup -setautoproxyurl "Wi-Fi" "` + proxy_url + `"`
+
+			fmt.Println(`To configure the proxy on your terminal execute:
+			export http_proxy=http://127.0.0.1:` + config.Port)
+		}
+
+		cmd.Stdin = strings.NewReader(script)
+		err := cmd.Run()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+	default:
+		fmt.Println(`
+List of supported system
+
+-linux-gnome
+-osx
+
+For more support please open an issue on: https://github.com/cristianoliveira/ergo
+		`)
+	}
+
+	fmt.Println("Ergo proxy setup executed.")
+}

--- a/resources/linux-gnome-setup-runner.sh
+++ b/resources/linux-gnome-setup-runner.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+finish() {
+  # these should probably revert to original settings
+  gsettings set org.gnome.system.proxy mode "none"
+  gsettings set org.gnome.system.proxy autoconfig-url ''
+}
+trap finish EXIT
+
+gsettings set org.gnome.system.proxy mode 'auto'
+gsettings set org.gnome.system.proxy autoconfig-url http://127.0.0.1:2000/proxy.pac
+
+ergo run

--- a/resources/osx-setup-runner.sh
+++ b/resources/osx-setup-runner.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+finish() {
+  for s in `networksetup -listallnetworkservices | sed -e '1d'`; do
+    sudo networksetup -setautoproxyurl "$s" ""
+  done
+}
+trap finish EXIT
+
+for s in `networksetup -listallnetworkservices | sed -e '1d'`; do
+  sudo networksetup -setautoproxyurl "$s" "http://localhost:2000/proxy.pac"
+done
+
+ergo run


### PR DESCRIPTION
Added the command for easy setup and included scripts on `/resources` for whom needs an ephemeral proxy setup  

This may refer to #12