### PR TITLE
switch integration tests off unless INTEGRATION_TEST environment variable is present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all: deps bump-version build test
 VERSION=`cat .version`
 LDFLAGS_f1=-ldflags "-w -s -X main.VERSION=${VERSION}"
 
+
 build-darwin-arm:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o bin/darwin/ergo
 
@@ -24,11 +25,14 @@ build: bump-version
 start:
 	@go run main.go run
 
-test:
-	@go test ./... -v
+test: build
+	@INTEGRATION_TEST=true go test ./... -v
 
 watch:
 	funzzy watch
+
+clean:
+	rm bin/ergo
 
 deps:
 	@go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' ./... | sort | uniq | grep -v ergo | go get

--- a/tests/ergo_run_test.go
+++ b/tests/ergo_run_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -12,10 +13,22 @@ func ergo(args ...string) *exec.Cmd {
 	return exec.Command("../bin/ergo", args...)
 }
 
+func integrationDisabled() bool {
+	value, found := os.LookupEnv("INTEGRATION_TEST")
+	if found == false || value == "false" {
+		return true
+	}
+
+	return false
+}
 func TestIntegration(t *testing.T) {
 	// TODO: create tests for windows
 	if runtime.GOOS == "windows" {
 		t.Skipf("skipping test on %q", runtime.GOOS)
+	}
+
+	if integrationDisabled() {
+		t.Skip("skipping integration tests - run with INTEGRATION_TEST=true to include")
 	}
 
 	t.Run("it lists the apps", func(tt *testing.T) {


### PR DESCRIPTION
Fixes #26 

Implemented as an environment variable rather than flag to avoid 'flag not defined' issues.