### PR TITLE
Work on tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ start:
 	@go run main.go run
 
 test: build
-	@INTEGRATION_TEST=true go test ./... -v
+	go test -tags=integration -v ./... 
 
 watch:
 	funzzy watch

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,4 +57,4 @@ deploy:
     appveyor_repo_tag: true
 
 test_script:
-  - go test ./... -v
+  - ./make.ps1 test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,4 +57,5 @@ deploy:
     appveyor_repo_tag: true
 
 test_script:
-  - ./make.ps1 test
+
+  - powershell -File make.ps1 -test

--- a/commands/url.go
+++ b/commands/url.go
@@ -12,6 +12,7 @@ import (
 // `ergo url foo`
 func URL(name string, config *proxy.Config) {
 	for _, s := range config.Services {
+
 		if name == s.Name {
 
 			localURL := s.Name + config.Domain

--- a/commands/url.go
+++ b/commands/url.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"regexp"
+
 	"github.com/cristianoliveira/ergo/proxy"
 )
 
@@ -11,8 +13,17 @@ import (
 func URL(name string, config *proxy.Config) {
 	for _, s := range config.Services {
 		if name == s.Name {
-			localUrl := `http://` + s.Name + config.Domain
-			fmt.Println(localUrl)
+
+			localURL := s.Name + config.Domain
+
+			//a protocol legth between 3 and 8 should fit all protocols
+			valid := regexp.MustCompile("^\\w{3,8}\\:\\/\\/.*$")
+
+			if !valid.MatchString(s.Name) {
+				localURL = `http://` + localURL
+			}
+
+			fmt.Println(localURL)
 		}
 	}
 }

--- a/make.ps1
+++ b/make.ps1
@@ -1,0 +1,66 @@
+param(
+    [switch]$build_darwin,
+    [switch]$build_linux_arm,
+    [switch]$build_linux_x64,
+    [switch]$build,
+    [switch]$bump_version,
+    [switch]$start,
+    [switch]$test,
+    [switch]$clean
+)
+
+function build(){
+    go build -o bin/ergo.exe
+}
+
+if($build_darwin_arm) {
+    Write-Host "Building darwin executable ..."
+    &{$CGO_ENABLED=0;$GOOS="darwin";$GOARCH="amd64"; go build -o bin/darwin/ergo}    
+}
+if($build_linux_arm) {
+    Write-Host "Building linux executable for the arm platform ..."
+    &{$CGO_ENABLED=0;$GOOS="linux";$GOARCH="arm64"; go build -o bin/darwin/ergo}    
+}
+if($build_linux_x64) {
+    Write-Host "Building linux executable for the 64 bit platform ..."
+    &{$CGO_ENABLED=0;$GOOS="linux";$GOARCH="amd64"; go build -o bin/ergo}
+}
+if($build){
+    Write-Host "Building windows executable ..."
+    build
+}
+if($clean){
+    Write-Host "Cleaning ..."
+    Remove-Item -Recurse -Force .\bin\*
+}
+if($test){
+    Write-Host "Starting tests ..."
+    build
+    go test -v -tags=integration ./... 
+}
+if($bump_version){
+    git tag --sort=committerdate | tail -n 1 > .version
+    Get-Content .version
+}
+
+function showHelp{
+    Write-Host "Usage: 
+    .\make.ps1 -build_darwin            build an executable for MacOS
+    .\make.ps1 -build_linux_arm         build an executable for linux on arm platform
+    .\make.ps1 -build_linux_x64         build an executable for linux on x64 platform
+    .\make.ps1 -build                   build an executable for windows
+    .\make.ps1 -bump_version            bump the app version
+    .\make.ps1 -start                   start the ergo proxy
+    .\make.ps1 -test                    run the tests
+    .\make.ps1 -clean                   remove all the created executables
+    "
+}
+
+if(!$build -and !$build_darwin -and 
+    !$build_linux_arm -and !$build_linux_x64 -and
+    !$bump_version -and !$start -and
+    !$test -and !$clean){
+        showHelp
+}
+
+

--- a/tests/ergo_run_test.go
+++ b/tests/ergo_run_test.go
@@ -79,7 +79,7 @@ func TestShowUrlForName(t *testing.T){
 			"withspaces":         "http://withspaces.dev",
 			"one.domain":         "http://one.domain.dev",
 			"two.domain":         "http://two.domain.dev",
-			"redis://redislocal": "http://redis://redislocal.dev",
+			"redis://redislocal": "redis://redislocal.dev",
 		}
 
 		for name, url := range appsOutput {
@@ -89,7 +89,7 @@ func TestShowUrlForName(t *testing.T){
 				tt.Fatal(err)
 			}
 
-			output := string(bs)			
+			output := string(bs)
 			if strings.Trim(output," \r\n")!=url {
 				tt.Errorf("Expected output:\n [%s] \n got [%s]", url, strings.Trim(output," \r\n"))
 			}

--- a/tests/ergo_run_test.go
+++ b/tests/ergo_run_test.go
@@ -1,36 +1,21 @@
+// +build integration
+
 package main
 
 import (
 	"fmt"
 	"log"
-	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 	"testing"
+	"path/filepath"
 )
 
 func ergo(args ...string) *exec.Cmd {
-	return exec.Command("../bin/ergo", args...)
+	return exec.Command(filepath.Join("..","bin","ergo"), args...)
 }
 
-func integrationDisabled() bool {
-	value, found := os.LookupEnv("INTEGRATION_TEST")
-	if found == false || value == "false" {
-		return true
-	}
-
-	return false
-}
-func TestIntegration(t *testing.T) {
-	// TODO: create tests for windows
-	if runtime.GOOS == "windows" {
-		t.Skipf("skipping test on %q", runtime.GOOS)
-	}
-
-	if integrationDisabled() {
-		t.Skip("skipping integration tests - run with INTEGRATION_TEST=true to include")
-	}
+func TestListApps(t *testing.T) {	
 
 	t.Run("it lists the apps", func(tt *testing.T) {
 		appsOutput := []string{
@@ -56,6 +41,9 @@ func TestIntegration(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestListAppNames(t *testing.T){
 
 	t.Run("it lists the app names", func(tt *testing.T) {
 		appsOutput := []string{
@@ -81,27 +69,29 @@ func TestIntegration(t *testing.T) {
 			}
 		}
 	})
+}
+func TestShowUrlForName(t *testing.T){ 
 
 	t.Run("it shows the url for a given name", func(tt *testing.T) {
 		appsOutput := map[string]string{
-			"foo":                "http://localhost:3000",
-			"bla":                "http://localhost:5000",
-			"withspaces":         "http://localhost:8080",
-			"one.domain":         "http://localhost:8081",
-			"two.domain":         "http://localhost:8082",
-			"redis://redislocal": "redis://localhost:6543",
+			"foo":                "http://foo.dev",
+			"bla":                "http://bla.dev",
+			"withspaces":         "http://withspaces.dev",
+			"one.domain":         "http://one.domain.dev",
+			"two.domain":         "http://two.domain.dev",
+			"redis://redislocal": "http://redis://redislocal.dev",
 		}
 
 		for name, url := range appsOutput {
-			cmd := ergo("list-names", "foo")
+			cmd := ergo("url", name)
 			bs, err := cmd.Output()
 			if err != nil {
 				tt.Fatal(err)
 			}
 
-			output := string(bs)
-			if !strings.Contains(output, url) {
-				tt.Errorf("Expected output:\n %s \n got %s", output, name)
+			output := string(bs)			
+			if strings.Trim(output," \r\n")!=url {
+				tt.Errorf("Expected output:\n [%s] \n got [%s]", url, strings.Trim(output," \r\n"))
 			}
 		}
 	})


### PR DESCRIPTION
Add integration flag [http://peter.bourgon.org/go-in-production/#testing-and-validation](http://peter.bourgon.org/go-in-production/#testing-and-validation) recommends using the tags for integration. I use the same in my projects. I believe it is clearer. But of course, it is only an option.

Add windows support for testing. 
Add windows make clone.
The make for windows is meant to be run in powershell. 
It follows the same model as linux make (as close as possible).
It was tested on windows 10.

Fix test for url 
Split the tests