### PR TITLE
handle invalid declaration format

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,7 +59,11 @@ func main() {
 	configFile := command.String("config", "./.ergo", "Set the services file")
 	command.Parse(os.Args[2:])
 
-	config.Services = proxy.LoadServices(*configFile)
+	services, err := proxy.LoadServices(*configFile)
+	if err != nil {
+		fmt.Printf("Could not load services: %v\n", err)
+	}
+	config.Services = services
 
 	switch os.Args[1] {
 	case "list":

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/cristianoliveira/ergo/commands"
@@ -61,7 +62,7 @@ func main() {
 
 	services, err := proxy.LoadServices(*configFile)
 	if err != nil {
-		fmt.Printf("Could not load services: %v\n", err)
+		log.Printf("Could not load services: %v\n", err)
 	}
 	config.Services = services
 

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -53,13 +53,13 @@ func NewService(name, url string) Service {
 	}
 }
 
-//LoadServices loads the services from filepath
-func LoadServices(filepath string) []Service {
+//LoadServices loads the services from filepath, returns an error
+//if the configuration could not be parsed
+func LoadServices(filepath string) ([]Service, error) {
 	file, e := os.Open(filepath)
 	defer file.Close()
 	if e != nil {
-		fmt.Printf("File error: %v\n", e)
-		os.Exit(1)
+		return nil, fmt.Errorf("file error: %v", e)
 	}
 
 	services := []Service{}
@@ -74,14 +74,13 @@ func LoadServices(filepath string) []Service {
 			continue
 		}
 		if len(config) != 2 {
-			fmt.Printf("File error: invalid format `%v` expected `{NAME} {URL}`\n", line)
-			os.Exit(1)
+			return nil, fmt.Errorf("file error: invalid format `%v` expected `{NAME} {URL}`", line)
 		}
 		name, url := config[0], config[1]
 		services = append(services, Service{Name: name, URL: url})
 	}
 
-	return services
+	return services, nil
 }
 
 //AddService adds new service to the filepath

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -70,10 +70,15 @@ func LoadServices(filepath string) []Service {
 
 		declaration := regexp.MustCompile(`(\S+)`)
 		config := declaration.FindAllString(line, -1)
-		if config != nil {
-			name, url := config[0], config[1]
-			services = append(services, Service{Name: name, URL: url})
+		if config == nil {
+			continue
 		}
+		if len(config) != 2 {
+			fmt.Printf("File error: invalid format `%v` expected `{NAME} {URL}`\n", line)
+			os.Exit(1)
+		}
+		name, url := config[0], config[1]
+		services = append(services, Service{Name: name, URL: url})
 	}
 
 	return services

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -9,7 +9,7 @@ func TestWhenHasErgoFile(t *testing.T) {
 	config := NewConfig()
 	services, err := LoadServices("../.ergo")
 	if err != nil {
-		t.Errorf("could not load requied configuration file for tests")
+		t.Errorf("could not load required configuration file for tests")
 		t.FailNow()
 	}
 

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -9,8 +9,7 @@ func TestWhenHasErgoFile(t *testing.T) {
 	config := NewConfig()
 	services, err := LoadServices("../.ergo")
 	if err != nil {
-		t.Errorf("could not load required configuration file for tests")
-		t.FailNow()
+		t.Fatal("could not load requied configuration file for tests")
 	}
 
 	config.Services = services
@@ -88,7 +87,7 @@ func TestWhenHasErgoFile(t *testing.T) {
 		fileContent, err := ioutil.ReadFile("../.ergo")
 
 		if err != nil {
-			tt.Skipf("Could not load initial .ergo file")
+			tt.Skip("Could not load initial .ergo file")
 		}
 
 		defer ioutil.WriteFile("../.ergo", fileContent, 0755)
@@ -97,7 +96,7 @@ func TestWhenHasErgoFile(t *testing.T) {
 		AddService("../.ergo", service)
 		_, err = LoadServices("../.ergo")
 		if err == nil {
-			tt.Errorf("Expected LoadServices to fail")
+			tt.Error("Expected LoadServices to fail")
 		}
 	})
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -13,8 +13,7 @@ func TestWhenHasCollectionFile(t *testing.T) {
 	config := NewConfig()
 	services, err := LoadServices("../.ergo")
 	if err != nil {
-		t.Errorf("could not load required configuration file for tests")
-		t.FailNow()
+		t.Fatal("could not load requied configuration file for tests")
 	}
 	config.Services = services
 	proxy := NewErgoProxy(config)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -13,7 +13,7 @@ func TestWhenHasCollectionFile(t *testing.T) {
 	config := NewConfig()
 	services, err := LoadServices("../.ergo")
 	if err != nil {
-		t.Errorf("could not load requied configuration file for tests")
+		t.Errorf("could not load required configuration file for tests")
 		t.FailNow()
 	}
 	config.Services = services

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -11,7 +11,12 @@ import (
 
 func TestWhenHasCollectionFile(t *testing.T) {
 	config := NewConfig()
-	config.Services = LoadServices("../.ergo")
+	services, err := LoadServices("../.ergo")
+	if err != nil {
+		t.Errorf("could not load requied configuration file for tests")
+		t.FailNow()
+	}
+	config.Services = services
 	proxy := NewErgoProxy(config)
 
 	t.Run("it redirects foo.dev to localhost 3000", func(t *testing.T) {


### PR DESCRIPTION
Gracefully handle case where service declaration has an invalid format.

Fixes https://github.com/cristianoliveira/ergo/issues/32