### PR TITLE
Tests separation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all start build test deps
+.PHONY: all start build test test-integration deps
 
-all: deps bump-version build test
+all: deps bump-version test build test-integration
 
 VERSION=`cat .version`
 LDFLAGS_f1=-ldflags "-w -s -X main.VERSION=${VERSION}"
@@ -25,7 +25,10 @@ build: bump-version
 start:
 	@go run main.go run
 
-test: build
+test: 
+	go test -v ./...
+
+test-integration: build
 	go test -tags=integration -v ./... 
 
 watch:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,4 +58,4 @@ deploy:
 
 test_script:
 
-  - powershell -File make.ps1 -test
+  - powershell -File make.ps1 -test-integration

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"io/ioutil"
 	"testing"
 )
 
@@ -13,7 +14,8 @@ func TestWhenHasErgoFile(t *testing.T) {
 		result := len(config.Services)
 
 		if expected != result {
-			t.Errorf("Expected %d got %d", expected, result)
+			t.Errorf("Expected to get %d services, but got %d\r\n%q",
+				expected, result, config.Services)
 		}
 	})
 
@@ -70,10 +72,20 @@ func TestWhenHasErgoFile(t *testing.T) {
 	})
 
 	t.Run("It adds new service", func(tt *testing.T) {
+		fileContent, err := ioutil.ReadFile("../.ergo")
+
+		if err != nil {
+			tt.Skipf("Could not load initial .ergo file")
+		}
+
+		//we clean after the test. Otherwise the next test will fail
+		defer ioutil.WriteFile("../.ergo", fileContent, 0755)
+
 		service := NewService("testservice", "http://localhost:8080")
 
 		if err := AddService("../.ergo", service); err != nil {
 			tt.Errorf("Expected service to be added")
 		}
+
 	})
 }

--- a/tests/ergo_run_test.go
+++ b/tests/ergo_run_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"path/filepath"
+	"io/ioutil"
 )
 
 func ergo(args ...string) *exec.Cmd {
@@ -96,8 +97,19 @@ func TestShowUrlForName(t *testing.T){
 		}
 	})
 
+}
+
+func TestAddService (t *testing.T){
 	t.Run("it adds new service if not present", func(tt *testing.T) {
 		appsOutput := fmt.Sprintf("%s\n", "Service added successfully!")
+
+		fileContent, err := ioutil.ReadFile("./.ergo")
+
+		if err == nil {
+			//we clean after the test. Otherwise the next test will fail
+			defer ioutil.WriteFile("./.ergo", fileContent, 0755)
+		}
+		
 
 		cmd := ergo("add", "new.service", "http://localhost:8083")
 		bs, err := cmd.Output()
@@ -127,14 +139,15 @@ func TestShowUrlForName(t *testing.T){
 			tt.Errorf("Expected output:\n %s \n got %s", appsOutput, output)
 		}
 	})
-	// TODO: Add tests for server
-	//
-	// t.Run("it runs binding the sites", func(tt *testing.T) {
-	// 	cmd := ergo("run", "-p", "25000")
-	// 	defer cmd.Process.Kill()
-	// 	err := cmd.Run()
-	// 	if err != nil {
-	// 		tt.Fatal(err)
-	// 	}
-	// })
 }
+
+// TODO: Add tests for server
+//
+// t.Run("it runs binding the sites", func(tt *testing.T) {
+// 	cmd := ergo("run", "-p", "25000")
+// 	defer cmd.Process.Kill()
+// 	err := cmd.Run()
+// 	if err != nil {
+// 		tt.Fatal(err)
+// 	}
+// })


### PR DESCRIPTION
Solves #34 
Also I've fixed some tests that could cause a second run to fail. This is not visible in Travis or Appveyor, as there every environment is pristine, but when run on the local computer, every time the tests were run, but the first one, they failed.
These tests wrote data to the initial .ergo files.