### PR TITLE
Add setup and run tests

### DIFF
--- a/commands/setup.go
+++ b/commands/setup.go
@@ -19,7 +19,7 @@ import (
 // Usage:
 // `ergo setup osx`
 func Setup(system string, remove bool, config *proxy.Config) {
-	
+
 	fmt.Println("Current detected system: " + runtime.GOOS)
 	proxyURL := "http://127.0.0.1:" + config.Port + "/proxy.pac"
 	script := ""

--- a/commands/setup_hlp.go
+++ b/commands/setup_hlp.go
@@ -2,9 +2,10 @@
 
 package commands
 
-//ShowInternetOptions is just a dummy for now 
+//ShowInternetOptions is just a dummy for now
 //this is only used for Windows
 func ShowInternetOptions() {}
+
 //InetRefresh is just a dummy. It only has functionality
 //in Windows
-func InetRefresh()         {}
+func InetRefresh() {}

--- a/make.ps1
+++ b/make.ps1
@@ -11,7 +11,7 @@ param(
 )
 
 function bumpVersion {
-    git tag --sort=committerdate | tail -n 1 > .version
+    git tag --sort=committerdate | Select-Object -Last 1 > .version
     Get-Content .version
 }
 function build(){
@@ -64,6 +64,7 @@ function showHelp{
     .\make.ps1 -bump_version            bump the app version
     .\make.ps1 -start                   start the ergo proxy
     .\make.ps1 -test                    run the tests
+    .\make.ps1 -test-integration        run the integration tests
     .\make.ps1 -clean                   remove all the created executables
     "
 }

--- a/tests/ergo_run_test.go
+++ b/tests/ergo_run_test.go
@@ -4,19 +4,25 @@ package main
 
 import (
 	"fmt"
+	"github.com/cristianoliveira/ergo/commands"
+	"io/ioutil"
 	"log"
+	"net/http"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
-	"path/filepath"
-	"io/ioutil"
+	"time"
 )
 
+var initialSetup interface{}
+
 func ergo(args ...string) *exec.Cmd {
-	return exec.Command(filepath.Join("..","bin","ergo"), args...)
+	return exec.Command(filepath.Join("..", "bin", "ergo"), args...)
 }
 
-func TestListApps(t *testing.T) {	
+func TestListApps(t *testing.T) {
 
 	t.Run("it lists the apps", func(tt *testing.T) {
 		appsOutput := []string{
@@ -44,7 +50,7 @@ func TestListApps(t *testing.T) {
 	})
 }
 
-func TestListAppNames(t *testing.T){
+func TestListAppNames(t *testing.T) {
 
 	t.Run("it lists the app names", func(tt *testing.T) {
 		appsOutput := []string{
@@ -71,7 +77,7 @@ func TestListAppNames(t *testing.T){
 		}
 	})
 }
-func TestShowUrlForName(t *testing.T){ 
+func TestShowUrlForName(t *testing.T) {
 
 	t.Run("it shows the url for a given name", func(tt *testing.T) {
 		appsOutput := map[string]string{
@@ -91,15 +97,15 @@ func TestShowUrlForName(t *testing.T){
 			}
 
 			output := string(bs)
-			if strings.Trim(output," \r\n")!=url {
-				tt.Errorf("Expected output:\n [%s] \n got [%s]", url, strings.Trim(output," \r\n"))
+			if strings.Trim(output, " \r\n") != url {
+				tt.Errorf("Expected output:\n [%s] \n got [%s]", url, strings.Trim(output, " \r\n"))
 			}
 		}
 	})
 
 }
 
-func TestAddService (t *testing.T){
+func TestAddService(t *testing.T) {
 	t.Run("it adds new service if not present", func(tt *testing.T) {
 		appsOutput := fmt.Sprintf("%s\n", "Service added successfully!")
 
@@ -109,7 +115,6 @@ func TestAddService (t *testing.T){
 			//we clean after the test. Otherwise the next test will fail
 			defer ioutil.WriteFile("./.ergo", fileContent, 0755)
 		}
-		
 
 		cmd := ergo("add", "new.service", "http://localhost:8083")
 		bs, err := cmd.Output()
@@ -141,13 +146,394 @@ func TestAddService (t *testing.T){
 	})
 }
 
-// TODO: Add tests for server
-//
-// t.Run("it runs binding the sites", func(tt *testing.T) {
-// 	cmd := ergo("run", "-p", "25000")
-// 	defer cmd.Process.Kill()
-// 	err := cmd.Run()
-// 	if err != nil {
-// 		tt.Fatal(err)
-// 	}
-// })
+// functions needed for setup and run testing
+func getOS() *string {
+	var runOS string
+	//we setup the right runtime
+	if runtime.GOOS == "windows" {
+		runOS = "windows"
+	} else if runtime.GOOS == "linux" {
+		//here we only have the tests for gnome
+		runOS = "linux-gnome"
+	} else if runtime.GOOS == "darwin" {
+		runOS = "osx"
+	}
+
+	return &runOS
+}
+
+func setupErgo() error {
+	var err error
+	runOS := getOS()
+
+	//we need to store the initial values to make sure they are restored
+	//linux-gnome
+	if *runOS == "linux-gnome" {
+		var mode string
+		var autoconfigURL string
+		mode, err = getLinuxGnomeProxyMode()
+		if err != nil {
+			return err
+		}
+		autoconfigURL, err = getLinuxGnomeProxyAutoConfig()
+		if err != nil {
+			return err
+		}
+		initialSetup = struct {
+			mode          string
+			autoconfigURL string
+		}{mode: mode, autoconfigURL: autoconfigURL}
+	}
+	//osx
+	if *runOS == "osx" {
+		var autoconfigURL string
+		autoconfigURL, err = getDarwinProxyAutoURL()
+		if err != nil {
+			return err
+		}
+		initialSetup = struct{ autoconfigURL string }{autoconfigURL: autoconfigURL}
+	}
+	//windows
+	if *runOS == "windows" {
+		var autoconfigURL string
+		autoconfigURL, err = getWindowsProxyAutoURL()
+		if err != nil {
+			return err
+		}
+		initialSetup = struct{ autoconfigURL string }{autoconfigURL: autoconfigURL}
+	}
+
+	if runOS != nil {
+		log.Println("starting setup " + *runOS)
+		cmd := ergo("setup", *runOS)
+		_, err := cmd.Output()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeSetupErgo() *exec.Cmd {
+	runOS := getOS()
+	if runOS != nil {
+		return ergo("setup", *runOS, "-remove")
+
+	}
+	return nil
+}
+
+func cleanSetup() error {
+	runOS := getOS()
+
+	//if initialSetup is not set, then the initial setup failed and there is no point
+	//trying to clean after it, anyway we can't since we do not have the initial info
+	if initialSetup == nil {
+		return nil
+	}
+
+	//we need to store the initial values to make sure they are restored
+	//linux-gnome
+	if *runOS == "linux-gnome" {
+		s := initialSetup.(struct {
+			mode          string
+			autoconfigURL string
+		})
+		return clearLinuxSetup(s.mode, s.autoconfigURL)
+	}
+	//osx
+	if *runOS == "osx" {
+		s := initialSetup.(struct{ autoconfigURL string })
+		return clearDarwinSetup(s.autoconfigURL)
+	}
+	//windows
+	if *runOS == "windows" {
+		s := initialSetup.(struct{ autoconfigURL string })
+		err := clearWindowsSetup(s.autoconfigURL)
+		if err != nil {
+			return err
+		}
+		commands.InetRefresh()
+	}
+	return nil
+}
+
+func getCommandResult(command string, args ...string) (string, error) {
+	cmd := exec.Command(command, args...)
+	rez, err := cmd.Output()
+
+	return string(rez), err
+}
+
+func getLinuxGnomeProxyMode() (string, error) {
+	return getCommandResult("gsettings", "get", "org.gnome.system.proxy", "mode")
+}
+
+func getLinuxGnomeProxyAutoConfig() (string, error) {
+	return getCommandResult("gsettings", "get", "org.gnome.system.proxy", "autoconfig-url")
+}
+
+func clearLinuxSetup(mode string, autoconfigURL string) error {
+	_, err := getCommandResult("gsettings", "set", "org.gnome.system.proxy", "mode", "'"+mode+"'")
+	if err != nil {
+		if err.Error() != "exit status 1" {
+			return err
+		} else {
+			return nil
+		}
+	}
+	_, err = getCommandResult("gsettings", "set", "org.gnome.system.proxy", "autoconfig-url", "'"+autoconfigURL+"'")
+
+	return err
+}
+
+func getDarwinProxyAutoURL() (string, error) {
+	return getCommandResult("sudo", "networksetup", "-getautoproxyurl", "\"Wi-Fi\"")
+}
+
+func clearDarwinSetup(autoconfigURL string) error {
+	_, err := getCommandResult("sudo", "networksetup", "-setautoproxyurl", "\"Wi-Fi\"", "'"+autoconfigURL+"'")
+
+	return err
+}
+
+func getWindowsProxyAutoURL() (string, error) {
+	rez, err := getCommandResult("reg", "query", "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", "/v", "AutoconfigURL")
+
+	//it is nromal to get an exit status 1 if we do not yet have the key in the registry
+	if err != nil && err.Error() != "exit status 1" {
+		return "", err
+	}
+	return rez, nil
+}
+
+func clearWindowsSetup(autoconfigURL string) error {
+	var err error
+
+	if autoconfigURL != "" {
+		_, err = getCommandResult("reg", "delete", `HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings`, "/v", "AutoConfigURL", "/f")
+	} else {
+		_, err = getCommandResult("reg", "add", `HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings`, "/v", "AutoConfigURL", "/t", "REG_SZ", "/d", autoconfigURL, "/f")
+	}
+
+	return err
+}
+func TestSetupLinuxGnome(t *testing.T) {
+
+	if *getOS() != "linux-gnome" {
+		t.Skip("Not running linux-gnome setup specific tests")
+	}
+	err := setupErgo()
+	if err != nil {
+		if err.Error() != "exit status 1" {
+			t.Fatalf("Could not perform setup for linux-gnome. Got %s", err.Error())
+		}
+		t.Skipf("Skipping test as gsettings does not exist on this system.")
+	}
+
+	defer cleanSetup()
+
+	ac, err := getLinuxGnomeProxyAutoConfig()
+	if err != nil {
+		t.Fatalf("No error expected while getting AutoconfigURL from gsettings. Got: %s, %s\r\n", err.Error(), ac)
+	}
+
+	if !strings.Contains(ac, "http://127.0.0.1:2000/proxy.pac") {
+		t.Fatalf("Expected to find \"http://127.0.0.1:2000/proxy.pac\" as part of the AutoconfigURL. Got \"%s\"\r\n", ac)
+	}
+
+	mode, err := getLinuxGnomeProxyMode()
+	if err != nil {
+		t.Fatalf("No error expected while getting \"mode\" from gsettings. Got: %s, %s\r\n", err.Error(), mode)
+	}
+
+	if strings.Contains(mode, "none") {
+		t.Fatalf("Expected to find a mode different then \"none\". Got \"%s\"\r\n", mode)
+	}
+
+}
+
+func TestSetupOSX(t *testing.T) {
+	if *getOS() != "osx" {
+		t.Skip("Not running osx setup specific tests")
+	}
+	err := setupErgo()
+	if err != nil {
+		t.Skipf("Please fix this for osx")
+		//t.Fatalf("Could not perform setup for osx. Got %s", err.Error())
+	}
+
+	defer cleanSetup()
+
+	ac, err := getDarwinProxyAutoURL()
+	if err != nil {
+		t.Fatalf("No error expected while getting AutoconfigURL from osx. Got: %s, %s\r\n", err.Error(), ac)
+	}
+
+	if !strings.Contains(ac, "http://127.0.0.1:2000/proxy.pac") {
+		t.Fatalf("Expected to find \"http://127.0.0.1:2000/proxy.pac\" as part of the AutoconfigURL. Got \"%s\"\r\n", ac)
+	}
+
+}
+
+func TestSetupWindows(t *testing.T) {
+	if *getOS() != "windows" {
+		t.Skip("Not running windows setup specific tests")
+	}
+	err := setupErgo()
+	if err != nil {
+		t.Fatalf("Could not perform setup for windows. Got %s", err.Error())
+	}
+
+	defer cleanSetup()
+
+	rez, err := getWindowsProxyAutoURL()
+	if err != nil {
+		t.Fatalf("No error expected while getting AutoconfigURL from registry. Got: %s, %s\r\n", err.Error(), rez)
+	}
+
+	if !strings.Contains(rez, "http://127.0.0.1:2000/proxy.pac") {
+		t.Fatalf("Expected to find \"http://127.0.0.1:2000/proxy.pac\" as part of the AutoconfigURL. Got \"%s\"\r\n", rez)
+	}
+
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "ergo test response")
+}
+
+//please change the ports if you change .ergo file
+//the server will be closed when the test finishes
+//not programatically
+//Perhaps a programatic approach should be used later
+func startTestWebServer() {
+	http.HandleFunc("/", handler)
+	go func() {
+		http.ListenAndServe(":5000", nil)
+	}()
+}
+
+//Please be aware that for windows you should have ports
+//2000 : ergo proxy
+// and
+//5000 : test web server
+//opened in
+//the firewall for this test to work
+func TestRunWindows(t *testing.T) {
+	if *getOS() != "windows" {
+		t.Skip("Not running windows run specific tests")
+	}
+	err := setupErgo()
+
+	if err != nil {
+		t.Fatalf("Could not perform setup for windows. Got %s", err.Error())
+	}
+
+	defer cleanSetup()
+
+	startTestWebServer()
+
+	cmd := ergo("run")
+	if cmd != nil {
+		defer func() {
+			if !cmd.ProcessState.Exited() {
+				cmd.Process.Kill()
+			}
+		}()
+	}
+	go func() {
+		cmd.Run()
+	}()
+
+	time.Sleep(2 * time.Second)
+
+	//it would be much easier to use Invoke-WebRequest, but using this makes it compatible with
+	//powershell 2.0 (windows 7)
+	rez, err := getCommandResult("powershell", "-c", "$proxy=[System.Net.WebRequest]::GetSystemWebProxy();",
+		"$webclient=new-object system.net.webclient;", "$webclient.proxy=$proxy;",
+		"$webclient.DownloadString('http://bla.dev')")
+
+	if err != nil {
+		t.Fatalf("Expected no error while requesting http://bla.dev, Got %s\r\n", err.Error())
+	}
+	if strings.Trim(rez, " \r\n") != "ergo test response" {
+		t.Fatalf("Expected \"ergo test response\" as response and got: %s\r\n", rez)
+	}
+}
+
+func TestRunLinuxGnome(t *testing.T) {
+	if *getOS() != "linux-gnome" {
+		t.Skip("Not running linux-gnome run specific tests")
+	}
+	err := setupErgo()
+	//exit status 1 means that gsettings was not found. So if linux is not really gnome, this will fails otherwise
+	if err != nil && err.Error() != "exit status 1" {
+		t.Fatalf("Could not perform setup for linux-gnome. Got %s", err.Error())
+	}
+
+	defer cleanSetup()
+
+	startTestWebServer()
+
+	cmd := ergo("run")
+	if cmd != nil {
+		defer func() {
+			if cmd != nil && cmd.ProcessState != nil && !cmd.ProcessState.Exited() {
+				cmd.Process.Kill()
+			}
+		}()
+	}
+	go func() {
+		cmd.Run()
+	}()
+
+	time.Sleep(2 * time.Second)
+
+	//it would be better perhaps to use a brower like chrome-headless
+	rez, err := getCommandResult("./testCurl.sh")
+
+	if err != nil {
+		t.Fatalf("Expected no error while requesting http://bla.dev, Got %s\r\n", err.Error())
+	}
+	if strings.Trim(rez, " \r\n") != "ergo test response" {
+		t.Fatalf("Expected \"ergo test response\" as response and got: %s\r\n", rez)
+	}
+}
+
+func TestRunOSX(t *testing.T) {
+	if *getOS() != "osx" {
+		t.Skip("Not running osx run specific tests")
+	}
+	err := setupErgo()
+	if err != nil {
+		t.Skip("Please fix this ... mac people")
+	}
+
+	defer cleanSetup()
+
+	startTestWebServer()
+
+	cmd := ergo("run")
+	if cmd != nil {
+		defer func() {
+			if cmd != nil && cmd.ProcessState != nil && !cmd.ProcessState.Exited() {
+				cmd.Process.Kill()
+			}
+		}()
+	}
+	go func() {
+		cmd.Run()
+	}()
+
+	time.Sleep(2 * time.Second)
+
+	//it would be better perhaps to use a brower like chrome-headless
+	rez, err := getCommandResult("./testCurl.sh")
+
+	if err != nil {
+		t.Fatalf("Expected no error while requesting http://bla.dev, Got %s\r\n", err.Error())
+	}
+	if strings.Trim(rez, " \r\n") != "ergo test response" {
+		t.Fatalf("Expected \"ergo test response\" as response and got: %s\r\n", rez)
+	}
+}

--- a/tests/testCurl.sh
+++ b/tests/testCurl.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export http_proxy=http://127.0.0.1:2000
+curl http://bla.dev


### PR DESCRIPTION
### Please do not merge. I will try to also make the **run** tests on linux. (Edit: done)

Solves #16 

**Setup test** is written and run for:
- **osx**
- **linux-gnome**
- **windows**
I cannot test **osx**, as I do not have any at my disposal, so, if someone can, please run the tests on mac and fix them as needed.

**Run test** is only written and run for **windows** as windows can use the system proxy using its shell (powershell). (Edit: I've also added tests for **Linux** and **OSX** now)
Perhaps a better approach would be to use chrome headless for example (perhaps even protractor might work). 
Chrome-headless nonetheless would require a chrome installation on the machine, and this is not necessary the case for each development environment.
An unitary approach might be more desirable than a separate one for each environment.
I propose to open a separate issue on this to establish a direction to take at a later date. 
