### PR TITLE
Add fmt vet lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,35 @@
-.PHONY: all start build test test-integration deps
+NO_COLOR=\33[0m
 
-all: deps bump-version test build test-integration
+OK_COLOR=\33[32m
+
+ERROR_COLOR=\033[31m
+
+WARN_COLOR=\33[33m
+
+.PHONY: all start build test test-integration deps help fmt vet lint tools 
 
 VERSION=`cat .version`
 LDFLAGS_f1=-ldflags "-w -s -X main.VERSION=${VERSION}"
 
+help:
+	@(echo "${WARN_COLOR}Usage:${NO_COLOR}")
+	@(echo "${OK_COLOR}make all${NO_COLOR}                      Run the tests and build the executable")
+	@(echo "${OK_COLOR}make help${NO_COLOR}                     Show this help") 
+	@(echo "${OK_COLOR}make build-darwin-arm${NO_COLOR}         Builds the executable for osx arm")
+	@(echo "${OK_COLOR}make build-linux-arm${NO_COLOR}          Builds the executable for linux arm")
+	@(echo "${OK_COLOR}make build-windows-i386${NO_COLOR}       Builds the executable for windows")
+	@(echo "${OK_COLOR}make bump-version${NO_COLOR}             Write the new version for latter use")
+	@(echo "${OK_COLOR}make build${NO_COLOR}                    Builds the executable for current system")
+	@(echo "${OK_COLOR}make start${NO_COLOR}                    Starts ergo")
+	@(echo "${OK_COLOR}make fmt${NO_COLOR}                      Run gofmt on the source code")
+	@(echo "${OK_COLOR}make vet${NO_COLOR}                      Run go vet on the source code")
+	@(echo "${OK_COLOR}make test${NO_COLOR}                     Run the unit tests")
+	@(echo "${OK_COLOR}make test-integration${NO_COLOR}         Run the integration tests")
+	@(echo "${OK_COLOR}make watch${NO_COLOR}                    Run funzzy watch")
+	@(echo "${OK_COLOR}make clean${NO_COLOR}                    Remove the compiled executables")
+	@(echo "${OK_COLOR}make deps${NO_COLOR}                     Get the dependencies needed to build the project")
+
+all: deps bump-version test build test-integration
 
 build-darwin-arm:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o bin/darwin/ergo
@@ -25,8 +50,29 @@ build: bump-version
 start:
 	@go run main.go run
 
-test: 
-	go test -v ./...
+tools:
+	@(go get github.com/golang/lint)
+
+fmt: 
+	@(echo "${OK_COLOR}Running fmt ...${NO_COLOR}")
+	@([ $$(gofmt -l . | wc -l) != 0 ] && \
+	echo "${WARN_COLOR}The following files are not correctly formated:${NO_COLOR}" && \
+	echo "${ERROR_COLOR}" && gofmt -l . && \
+	echo "${NO_COLOR}"  && exit 1 || exit 0)
+
+vet:
+	@(echo "${OK_COLOR}Running vet ...${NO_COLOR}")
+	go vet ./...
+
+lint: tools
+	@(echo "${OK_COLOR}Running lint ...${NO_COLOR}")
+	@(export PATH=$$PATH:$$GOPATH/bin && [ $$(golint ./... | wc -l) != 0 ] && \
+	echo "${WARN_COLOR}Lint says the following files are not ok:${NO_COLOR}" && \
+	echo "${ERROR_COLOR}" && golint ./... && \
+	echo "${NO_COLOR}"  && exit 1 || exit 0)
+
+test: fmt vet lint
+	@(go test -v ./...)
 
 test-integration: build
 	go test -tags=integration -v ./... 

--- a/commands/list.go
+++ b/commands/list.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+
 	"github.com/cristianoliveira/ergo/proxy"
 )
 
@@ -11,7 +12,7 @@ import (
 func List(config *proxy.Config) {
 	fmt.Println("Ergo Proxy current list: ")
 	for _, s := range config.Services {
-		localUrl := `http://` + s.Name + config.Domain
-		fmt.Printf(" - %s -> %s \n", localUrl, s.URL)
+		localURL := `http://` + s.Name + config.Domain
+		fmt.Printf(" - %s -> %s \n", localURL, s.URL)
 	}
 }

--- a/make.ps1
+++ b/make.ps1
@@ -7,9 +7,76 @@ param(
     [switch]$start,
     [switch]$test,
     [switch]$test_integration,
-    [switch]$clean
+    [switch]$clean,
+    [switch]$help,
+    [switch]$vet,
+    [switch]$fmt,
+    [switch]$lint,
+    [switch]$tools
 )
 
+function showHelp{
+    Write-Host "Usage: 
+    .\make.ps1 -build_darwin            build an executable for MacOS
+    .\make.ps1 -build_linux_arm         build an executable for linux on arm platform
+    .\make.ps1 -build_linux_x64         build an executable for linux on x64 platform
+    .\make.ps1 -build                   build the windows executable
+    .\make.ps1 -bump_version            bump the app version
+    .\make.ps1 -start                   start the ergo proxy
+    .\make.ps1 -fmt                     run gofmt on the source code    
+    .\make.ps1 -vet                     run go vet on the source code    
+    .\make.ps1 -lint                    run golint on the source code    
+    .\make.ps1 -tools                   obtain the tools needed to run different make targets
+    .\make.ps1 -test                    run the tests
+    .\make.ps1 -test-integration        run the integration tests
+    .\make.ps1 -clean                   remove all the created executables
+    "
+}
+
+function fmt() {
+    Write-Host "Running fmt ..." -ForegroundColor Green
+    $rez = $(gofmt -l .)
+    if($rez.Length -eq 0){
+        return 
+    }
+    $noOfLines = $(Measure-Object $rez | Select-Object -ExpandProperty Count)
+    if($noOfLines -ne 0){
+        Write-Warning -Message "The following files are not correctly formated:"
+        foreach($r in $rez){
+            Write-Host $r -ForegroundColor Red
+        }
+        exit $noOfLines
+    }
+}
+function vet(){
+    Write-Host "Running vet ..." -ForegroundColor Green
+    go vet ./...
+    if($LASTEXITCODE -ne 0){
+        exit $LASTEXITCODE
+    }
+}
+
+function tools(){
+    go get -u github.com/golang/lint/golint
+}
+
+function lint(){  
+    tools  
+    Write-Host "Running lint ..." -ForegroundColor Green
+    $Env:Path+=";"+"$Env:GOPATH\bin"
+    $rez = $(golint ./...)
+    if($rez.Length -eq 0){
+        return 
+    }
+    $noOfLines = $(Measure-Object $rez | Select-Object -ExpandProperty Count)
+    if($noOfLines -ne 0){
+        Write-Warning -Message "Lint says the following files are not ok:"
+        foreach($r in $rez){
+            Write-Host $r -ForegroundColor Red
+        }
+        exit $noOfLines
+    }
+}
 function bumpVersion {
     git tag --sort=committerdate | Select-Object -Last 1 > .version
     Get-Content .version
@@ -20,32 +87,35 @@ function build(){
 }
 
 if($build_darwin_arm) {
-    Write-Host "Building darwin executable ..."
+    Write-Host "Building darwin executable ..." -ForegroundColor Green
     &{$CGO_ENABLED=0;$GOOS="darwin";$GOARCH="amd64"; go build -o bin/darwin/ergo}    
 }
 if($build_linux_arm) {
-    Write-Host "Building linux executable for the arm platform ..."
+    Write-Host "Building linux executable for the arm platform ..." -ForegroundColor Green
     &{$CGO_ENABLED=0;$GOOS="linux";$GOARCH="arm64"; go build -o bin/darwin/ergo}    
 }
 if($build_linux_x64) {
-    Write-Host "Building linux executable for the 64 bit platform ..."
+    Write-Host "Building linux executable for the 64 bit platform ..." -ForegroundColor Green
     &{$CGO_ENABLED=0;$GOOS="linux";$GOARCH="amd64"; go build -o bin/ergo}
 }
 if($build){
-    Write-Host "Building windows executable ..."
+    Write-Host "Building windows executable ..." -ForegroundColor Green
     build
 }
 if($clean){
-    Write-Host "Cleaning ..."
+    Write-Host "Cleaning ..." -ForegroundColor Green
     Remove-Item -Recurse -Force .\bin\*
 }
-if($test){
-    Write-Host "Starting tests ..."
+if($test){    
+    fmt
+    vet
+    lint
+    Write-Host "Running tests ..." -ForegroundColor Green
     go test -v ./... 
 }
 
 if($test_integration) {
-    Write-Host "Starting integration tests ..."
+    Write-Host "Running integration tests ..." -ForegroundColor Green
     build
     go test -tags=integration -v ./... 
     
@@ -55,25 +125,32 @@ if($bump_version){
     bumpVersion
 }
 
-function showHelp{
-    Write-Host "Usage: 
-    .\make.ps1 -build_darwin            build an executable for MacOS
-    .\make.ps1 -build_linux_arm         build an executable for linux on arm platform
-    .\make.ps1 -build_linux_x64         build an executable for linux on x64 platform
-    .\make.ps1 -build                   build an executable for windows
-    .\make.ps1 -bump_version            bump the app version
-    .\make.ps1 -start                   start the ergo proxy
-    .\make.ps1 -test                    run the tests
-    .\make.ps1 -test-integration        run the integration tests
-    .\make.ps1 -clean                   remove all the created executables
-    "
+if($help){
+    showHelp
+}
+
+if($fmt){
+    fmt
+}
+
+if($vet){
+    vet
+}
+
+if($lint){
+    lint
+}
+
+if($tools){
+    tools
 }
 
 if(!$build -and !$build_darwin -and 
     !$build_linux_arm -and !$build_linux_x64 -and
     !$bump_version -and !$start -and
     !$test -and !$clean -and 
-    !$test_integration){
+    !$test_integration -and !$help -and
+    !$vet -and !$fmt -and !$lint){
         showHelp
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -94,8 +94,8 @@ func ServeProxy(config *Config) error {
 
 	http.HandleFunc("/_ergo/list", func(w http.ResponseWriter, r *http.Request) {
 		for _, s := range config.Services {
-			localUrl := `http://` + s.Name + config.Domain
-			fmt.Fprintf(w, "- %s -> %s \n", localUrl, s.URL)
+			localURL := `http://` + s.Name + config.Domain
+			fmt.Fprintf(w, "- %s -> %s \n", localURL, s.URL)
 		}
 	})
 


### PR DESCRIPTION
This adds fmt, vet and lint checks for all the tests.
This will make sure that no code that does not respect the Golang
recomended code style will be submited.
This should close #47