### PR TITLE
Add dynamic configuration reload

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,5 +57,5 @@ deploy:
     appveyor_repo_tag: true
 
 test_script:
-
-  - powershell -File make.ps1 -test_integration
+  - ps: .\make.ps1 -test
+  - ps: .\make.ps1 -test_integration

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func main() {
 		log.Printf("Could not load services: %v\n", err)
 	}
 	config.Services = services
+	config.ConfigFile = *configFile
 
 	switch os.Args[1] {
 	case "list":

--- a/tests/testCurlNotExisting.sh
+++ b/tests/testCurlNotExisting.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export http_proxy=http://127.0.0.1:2000
+curl http://dynamic.dev


### PR DESCRIPTION
This addresses #2 
Add basic monitoring of the config file.
The config file is checked for modification (size and modification time) every 500 ms (about twice per second if we ignore the rest of the calculations). If a modification is seen, the services are reloaded.
Possible improvements:
* Possible, at later time, a file modification notification from the OS could be used.
* A lock has been used to ensure that the __services__ are written in a thread safe way. Any latter modification of the __services__ variable of the __config__ should use the same lock.
(Edit) No lock is in use anymore. The synchronisation is done through a channel.