### PR TITLE
Add windows install script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,53 @@
+$installDir = "$Env:UserProfile\Ergo"
+$downloadTo = "$Env:TEMP\ergo.exe"
+
+function Test-RegistryValue {
+    param (
+     [parameter(Mandatory=$true)]
+     [ValidateNotNullOrEmpty()]$Path,
+    [parameter(Mandatory=$true)]
+     [ValidateNotNullOrEmpty()]$Value
+    )
+    
+    try {    
+        Get-ItemProperty -Path $Path | Select-Object -ExpandProperty $Value -ErrorAction Stop | Out-Null
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+    
+
+Write-Host "Ergo will be installed to: $installDir"
+
+$v = Get-Content .version | Out-String
+$v = $v.Trim()
+
+Invoke-WebRequest -Uri "https://github.com/cristianoliveira/ergo/releases/download/$v/ergo.exe" -OutFile $downloadTo
+
+If(!(Test-Path $installDir))
+{
+    New-Item -ItemType Directory -Force -Path $installDir
+}
+
+Copy-Item -Path "$downloadTo" -Dest "$installDir\ergo.exe"
+
+if(!(Test-Path "HKCU:\Environment"))
+{
+    New-Item -Path "HKCU:\Environment" -Force
+    #reg add "HKCU\Environment" /v Path /f /t REG_SZ /d "$Env:path;$installDir"
+}
+
+$pathNow = $installDir
+
+if(Test-RegistryValue -Path "HKCU:\Environment" -Value "Path"){
+    $pathNow = Get-ItemPropertyValue -Path HKCU:\Environment  -Name "Path"
+    $pathNow = "$pathNow;$installDir"
+}
+
+Write-Output $pathNow
+
+New-ItemProperty -Path "HKCU:\Environment" -Name "Path" -Value "$pathNow" -PropertyType String -Force
+
+setx ERGO_PATH "$installDir"


### PR DESCRIPTION
This solves #59
This install script is the equivalent of the linux/osx install script.
This will install ergo to ```%USERPROFILE%/Ergo/``` and will add it to the ```Path``` environment variable.
The last action is to set an environment variable named ```ERGO_HOME``` that can be later used perhaps to add/access the config file. 
After running this script the user should open a new prompt and will be able to run ergo directly.