### PR TITLE
Adds error when running ergo without a command

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,11 @@ setup:
 `
 
 func command() func() {
+	// Fail fast if we didn't receive a command argument
+	if len(os.Args) == 1 {
+		return nil
+	}
+
 	config := proxy.NewConfig()
 	command := flag.NewFlagSet(os.Args[1], flag.ExitOnError)
 	configFile := command.String("config", "./.ergo", "Set the services file")
@@ -124,11 +129,16 @@ func main() {
 		return
 	}
 
-	cmd := command()
-	showUsage := *help || len(os.Args) == 1 || cmd == nil
-
-	if showUsage {
+	if *help {
 		fmt.Println(USAGE)
+		return
+	}
+
+	cmd := command()
+
+	if cmd == nil {
+		fmt.Println(USAGE)
+		os.Exit(1)
 	} else {
 		cmd()
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"testing"
 )
 
@@ -12,6 +13,28 @@ func TestMain(t *testing.T) {
 
 		main()
 		// Output: USAGE
+	})
+}
+
+// TestMissingCommand will cause the main function to return a non-zero exit code
+// so we need to do some wrapping to make the test not fail.
+// For more info check ou to uset: https://talks.golang.org/2014/testing.slide#23
+func TestMissingCommand(t *testing.T) {
+	t.Run("missing a command so it shows usage", func(tt *testing.T) {
+		if os.Getenv("TEST_MISSING_COMMAND") == "1" {
+			args := []string{"ergo"}
+			os.Args = args
+
+			main()
+			// Output: USAGE and exit with an error code
+		}
+		cmd := exec.Command(os.Args[0], "-test.run=TestMissingCommand")
+		cmd.Env = append(os.Environ(), "TEST_MISSING_COMMAND=1")
+		err := cmd.Run()
+		if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+			return
+		}
+		t.Fatalf("process ran with err %v, want exit status 1", err)
 	})
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+var testExec = os.Args[0]
+
 func TestMain(t *testing.T) {
 	t.Run("it shows usage", func(tt *testing.T) {
 		args := []string{"ergo", "-h"}
@@ -28,7 +30,7 @@ func TestMissingCommand(t *testing.T) {
 			main()
 			// Output: USAGE and exit with an error code
 		}
-		cmd := exec.Command(os.Args[0], "-test.run=TestMissingCommand")
+		cmd := exec.Command(testExec, "-test.run=TestMissingCommand")
 		cmd.Env = append(os.Environ(), "TEST_MISSING_COMMAND=1")
 		err := cmd.Run()
 		if e, ok := err.(*exec.ExitError); ok && !e.Success() {


### PR DESCRIPTION
- Moves logic for print out help message to it's own conditional
- Checks length of arguments to the main command before building
  subcommands and returns nil if none provided
- Prints usage and returns non-zero exit code if incorrect command is
  attempted

Resolves #64 