### PR TITLE
refactor: Simplify tests and share code

### DIFF
--- a/commands/add_service_test.go
+++ b/commands/add_service_test.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -12,35 +11,11 @@ import (
 )
 
 func TestAddServiceAllreadyThere(t *testing.T) {
+	config := buildConfig([]proxy.Service{
+		proxy.Service{Name: "test.dev", URL: "localhost:9999"},
+	})
 
-	tmpfile, err := ioutil.TempFile("", "testaddservice")
-	if err != nil {
-		t.Fatalf("Error creating tempfile: %s", err.Error())
-	}
-
-	defer os.Remove(tmpfile.Name())
-
-	if _, err = tmpfile.Write([]byte("test.dev localhost:9999")); err != nil {
-		t.Fatalf("Error writing to temporary file: %s", err.Error())
-	}
-
-	if err = tmpfile.Close(); err != nil {
-		t.Fatalf("Error closing temp file: %s", err.Error())
-	}
-
-	if err != nil {
-		t.Fatalf("No error expected while initializing config file. Got %s.", err.Error())
-	}
-	config := proxy.Config{}
-	config.ConfigFile = tmpfile.Name()
-	config.Services, err = proxy.LoadServices(config.ConfigFile)
-
-	if err != nil {
-		t.Fatalf("No error expected while loading services from config file. Got %s.", err.Error())
-	}
-
-	service := proxy.Service{}
-	service.Name = config.Services[0].Name
+	service := proxy.Service{Name: "test.dev"}
 
 	old := os.Stdout
 	r, w, _ := os.Pipe()
@@ -68,36 +43,14 @@ func TestAddServiceAllreadyThere(t *testing.T) {
 }
 
 func TestAddServiceAddOK(t *testing.T) {
+	config := buildConfig([]proxy.Service{
+		proxy.Service{Name: "test.dev", URL: "localhost:9999"},
+	})
 
-	tmpfile, err := ioutil.TempFile("", "testaddservice")
-	if err != nil {
-		t.Fatalf("Error creating tempfile: %s", err.Error())
+	service := proxy.Service{
+		Name: "newtest.dev",
+		URL:  "http://localhost:3333",
 	}
-
-	defer os.Remove(tmpfile.Name())
-
-	if _, err = tmpfile.Write([]byte("test.dev localhost:9999")); err != nil {
-		t.Fatalf("Error writing to temporary file: %s", err.Error())
-	}
-
-	if err = tmpfile.Close(); err != nil {
-		t.Fatalf("Error closing temp file: %s", err.Error())
-	}
-
-	if err != nil {
-		t.Fatalf("No error expected while initializing config file. Got %s.", err.Error())
-	}
-	config := proxy.Config{}
-	config.ConfigFile = tmpfile.Name()
-	config.Services, err = proxy.LoadServices(config.ConfigFile)
-
-	if err != nil {
-		t.Fatalf("No error expected while loading services from config file. Got %s.", err.Error())
-	}
-
-	service := proxy.Service{}
-	service.Name = "newservice"
-	service.URL = "http://localhost:3333"
 
 	old := os.Stdout
 	r, w, _ := os.Pipe()
@@ -126,37 +79,16 @@ func TestAddServiceAddOK(t *testing.T) {
 
 func TestAddServiceFileNOK(t *testing.T) {
 
-	tmpfile, err := ioutil.TempFile("", "testaddservice")
-	if err != nil {
-		t.Fatalf("Error creating tempfile: %s", err.Error())
-	}
-
-	defer os.Remove(tmpfile.Name())
-
-	if _, err = tmpfile.Write([]byte("test.dev localhost:9999")); err != nil {
-		t.Fatalf("Error writing to temporary file: %s", err.Error())
-	}
-
-	if err = tmpfile.Close(); err != nil {
-		t.Fatalf("Error closing temp file: %s", err.Error())
-	}
-
-	if err != nil {
-		t.Fatalf("No error expected while initializing config file. Got %s.", err.Error())
-	}
-	config := proxy.Config{}
-	config.ConfigFile = tmpfile.Name()
-	config.Services, err = proxy.LoadServices(config.ConfigFile)
-
-	if err != nil {
-		t.Fatalf("No error expected while loading services from config file. Got %s.", err.Error())
-	}
+	config := buildConfig([]proxy.Service{
+		proxy.Service{Name: "test.dev", URL: "localhost:9999"},
+	})
 
 	config.ConfigFile = "anyfilethatdoesnotexist.here"
 
-	service := proxy.Service{}
-	service.Name = "newservice"
-	service.URL = "http://localhost:3333"
+	service := proxy.Service{
+		Name: "newtest.dev",
+		URL:  "http://localhost:3333",
+	}
 
 	old := os.Stdout
 	r, w, _ := os.Pipe()

--- a/commands/commands_helper_test.go
+++ b/commands/commands_helper_test.go
@@ -1,0 +1,19 @@
+package commands
+
+import (
+	"io/ioutil"
+
+	"github.com/cristianoliveira/ergo/proxy"
+)
+
+func buildConfig(services []proxy.Service) proxy.Config {
+	tmpfile, err := ioutil.TempFile("", "testaddservice")
+	if err != nil {
+		panic("Error creating tempfile" + err.Error())
+	}
+
+	return proxy.Config{
+		ConfigFile: tmpfile.Name(),
+		Services:   services,
+	}
+}

--- a/commands/list_names_test.go
+++ b/commands/list_names_test.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -13,34 +12,9 @@ import (
 
 func TestListNames(t *testing.T) {
 
-	tmpfile, err := ioutil.TempFile("", "testaddservice")
-	if err != nil {
-		t.Fatalf("Error creating tempfile: %s", err.Error())
-	}
-
-	defer os.Remove(tmpfile.Name())
-
-	if _, err = tmpfile.Write([]byte("test.dev localhost:9999")); err != nil {
-		t.Fatalf("Error writing to temporary file: %s", err.Error())
-	}
-
-	if err = tmpfile.Close(); err != nil {
-		t.Fatalf("Error closing temp file: %s", err.Error())
-	}
-
-	if err != nil {
-		t.Fatalf("No error expected while initializing config file. Got %s.", err.Error())
-	}
-	config := proxy.Config{}
-	config.ConfigFile = tmpfile.Name()
-	config.Services, err = proxy.LoadServices(config.ConfigFile)
-
-	if err != nil {
-		t.Fatalf("No error expected while loading services from config file. Got %s.", err.Error())
-	}
-
-	service := proxy.Service{}
-	service.Name = config.Services[0].Name
+	config := buildConfig([]proxy.Service{
+		proxy.Service{Name: "test.dev", URL: "localhost:9999"},
+	})
 
 	old := os.Stdout
 	r, w, _ := os.Pipe()

--- a/commands/list_test.go
+++ b/commands/list_test.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -13,34 +12,9 @@ import (
 
 func TestList(t *testing.T) {
 
-	tmpfile, err := ioutil.TempFile("", "testaddservice")
-	if err != nil {
-		t.Fatalf("Error creating tempfile: %s", err.Error())
-	}
-
-	defer os.Remove(tmpfile.Name())
-
-	if _, err = tmpfile.Write([]byte("test.dev localhost:9999")); err != nil {
-		t.Fatalf("Error writing to temporary file: %s", err.Error())
-	}
-
-	if err = tmpfile.Close(); err != nil {
-		t.Fatalf("Error closing temp file: %s", err.Error())
-	}
-
-	if err != nil {
-		t.Fatalf("No error expected while initializing config file. Got %s.", err.Error())
-	}
-	config := proxy.Config{}
-	config.ConfigFile = tmpfile.Name()
-	config.Services, err = proxy.LoadServices(config.ConfigFile)
-
-	if err != nil {
-		t.Fatalf("No error expected while loading services from config file. Got %s.", err.Error())
-	}
-
-	service := proxy.Service{}
-	service.Name = config.Services[0].Name
+	config := buildConfig([]proxy.Service{
+		proxy.Service{Name: "test.dev", URL: "localhost:9999"},
+	})
 
 	old := os.Stdout
 	r, w, _ := os.Pipe()

--- a/commands/url_test.go
+++ b/commands/url_test.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -13,34 +12,9 @@ import (
 
 func TestURL(t *testing.T) {
 
-	tmpfile, err := ioutil.TempFile("", "testaddservice")
-	if err != nil {
-		t.Fatalf("Error creating tempfile: %s", err.Error())
-	}
-
-	defer os.Remove(tmpfile.Name())
-
-	if _, err = tmpfile.Write([]byte("test.dev localhost:9999")); err != nil {
-		t.Fatalf("Error writing to temporary file: %s", err.Error())
-	}
-
-	if err = tmpfile.Close(); err != nil {
-		t.Fatalf("Error closing temp file: %s", err.Error())
-	}
-
-	if err != nil {
-		t.Fatalf("No error expected while initializing config file. Got %s.", err.Error())
-	}
-	config := proxy.Config{}
-	config.ConfigFile = tmpfile.Name()
-	config.Services, err = proxy.LoadServices(config.ConfigFile)
-
-	if err != nil {
-		t.Fatalf("No error expected while loading services from config file. Got %s.", err.Error())
-	}
-
-	service := proxy.Service{}
-	service.Name = config.Services[0].Name
+	config := buildConfig([]proxy.Service{
+		proxy.Service{Name: "test.dev", URL: "localhost:9999"},
+	})
 
 	old := os.Stdout
 	r, w, _ := os.Pipe()


### PR DESCRIPTION
I made some refactor on command tests. Created a helper function then we can share some functions for setting up the tests.