### PR TITLE
Add dynamic versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WARN_COLOR=\33[33m
 
 .PHONY: all start build test test-integration coverage deps help fmt vet lint tools
 
-VERSION=`cat .version`
+VERSION=`git describe --tag --always`
 LDFLAGS_f1=-ldflags "-w -s -X main.VERSION=${VERSION}"
 
 help:

--- a/make.ps1
+++ b/make.ps1
@@ -83,7 +83,7 @@ function bumpVersion {
 }
 function build(){
     bumpVersion
-    go build -ldflags "-w -s -X main.VERSION=$(Get-Content .\.version)" -o bin/ergo.exe
+    go build -ldflags "-w -s -X main.VERSION=$(git describe --tag --always)" -o bin/ergo.exe
 }
 
 if($build_darwin_arm) {


### PR DESCRIPTION
This mitigates #78 partially. 
This adds dynamic versioning for manual builds. 
This means that builds that happened after v0.2.0 will also have an appended git commit short description.
The releases, being based on tagged commits, will have the exact version (without the short commit).
This is useful to differentiate between releases and intermediary builds.
We can also eliminate the need for .version file if this will be approved.
An manual ```go build ``` will not add a version though, as it still doesn't add it now.