### PR TITLE
fix: Show default version if ldflag not specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 //VERSION of ergo.
-var VERSION string
+var VERSION = "unofficial build"
 
 //USAGE details the usage for ergo proxy.
 const USAGE = `

--- a/main.go
+++ b/main.go
@@ -11,8 +11,10 @@ import (
 	"github.com/cristianoliveira/ergo/proxy"
 )
 
-//VERSION of ergo.
-var VERSION = "unofficial build"
+// VERSION of ergo
+// When ergo is build without a proper tag/release it is named as `unofficial version`.
+// For instance, installing through `go get github.com/cristianoliveira/ergo` or `go build`.
+var VERSION = "unofficial version"
 
 //USAGE details the usage for ergo proxy.
 const USAGE = `


### PR DESCRIPTION
Hey, I implemented a fix, which was discussed in #78 .

I have read the project's contributing guidelines, where the fifth point says that I need to create tests for my changes. However, version command could not be tested without changing the flag parsing in main() method, hence I skipped that part.

Also, the contributing guidelines say about good commit messages, I looked up latest commits in the repo and came up with something similar.

Hope, I will be of any help for you, guys :smile: 