### PR TITLE
fix: AddService command config flag

### DIFF
--- a/commands/add_service.go
+++ b/commands/add_service.go
@@ -9,13 +9,13 @@ import (
 // AddService Allows to add new services to existing configuration file
 // Usage:
 // `ergo add service servicehost:port`
-func AddService(config *proxy.Config, service proxy.Service, configFile string) {
+func AddService(config *proxy.Config, service proxy.Service) {
 	oldService := config.GetService(service.Name + config.Domain)
 	if oldService != nil {
 		fmt.Println("Service already present!")
 	} else {
 		config.Services = append(config.Services, service)
-		err := proxy.AddService(configFile, service)
+		err := proxy.AddService(config.ConfigFile, service)
 		if err == nil {
 			fmt.Println("Service added successfully!")
 		} else {

--- a/commands/add_service_test.go
+++ b/commands/add_service_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAddServiceAllreadyThere(t *testing.T) {
 	config := buildConfig([]proxy.Service{
-		{Name: "test.dev", URL: "localhost:9999"},
+		proxy.Service{Name: "test.dev", URL: "localhost:9999"},
 	})
 
 	service := proxy.Service{Name: "test.dev"}
@@ -29,7 +29,7 @@ func TestAddServiceAllreadyThere(t *testing.T) {
 		outC <- buf.String()
 	}()
 
-	AddService(&config, service, config.ConfigFile)
+	AddService(&config, service)
 
 	w.Close()
 
@@ -44,7 +44,7 @@ func TestAddServiceAllreadyThere(t *testing.T) {
 
 func TestAddServiceAddOK(t *testing.T) {
 	config := buildConfig([]proxy.Service{
-		{Name: "test.dev", URL: "localhost:9999"},
+		proxy.Service{Name: "test.dev", URL: "localhost:9999"},
 	})
 
 	service := proxy.Service{
@@ -64,7 +64,7 @@ func TestAddServiceAddOK(t *testing.T) {
 		outC <- buf.String()
 	}()
 
-	AddService(&config, service, config.ConfigFile)
+	AddService(&config, service)
 
 	w.Close()
 
@@ -77,17 +77,19 @@ func TestAddServiceAddOK(t *testing.T) {
 	}
 }
 
-func TestAddServiceFileNOK(t *testing.T) {
-
+func TestAddServiceAddFileNotFound(t *testing.T) {
 	config := buildConfig([]proxy.Service{
-		{Name: "test.dev", URL: "localhost:9999"},
+		proxy.Service{Name: "test.dev", URL: "localhost:9999"},
 	})
-
-	config.ConfigFile = "anyfilethatdoesnotexist.here"
 
 	service := proxy.Service{
 		Name: "newtest.dev",
 		URL:  "http://localhost:3333",
+	}
+
+	newConfig := proxy.Config{
+		Services:   config.Services,
+		ConfigFile: "anyfilethatdoesnotexist.here",
 	}
 
 	old := os.Stdout
@@ -102,7 +104,7 @@ func TestAddServiceFileNOK(t *testing.T) {
 		outC <- buf.String()
 	}()
 
-	AddService(&config, service, config.ConfigFile)
+	AddService(&newConfig, service)
 
 	w.Close()
 
@@ -110,7 +112,7 @@ func TestAddServiceFileNOK(t *testing.T) {
 
 	out := <-outC
 
-	if !strings.Contains(out, "Error while adding new service") {
-		t.Fatalf("Expected AddService to refuse to add an service in an unexisting file. Got %s.", out)
+	if !strings.Contains(out, "Error") {
+		t.Fatalf("Expected AddService add a service. Got %s.", out)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -120,17 +120,27 @@ func command() func() {
 		url := os.Args[3]
 		service := proxy.NewService(name, url)
 
+		command = flag.NewFlagSet(os.Args[1], flag.ExitOnError)
+		command.StringVar(&config.ConfigFile, "config", "./.ergo", "Set the services file")
+		command.Parse(os.Args[4:])
+
+		services, err := proxy.LoadServices(config.ConfigFile)
+		if err != nil {
+			log.Printf("Could not load services: %v\n", err)
+		}
+		config.Services = services
+
 		return func() {
-			commands.AddService(config, service, *configFile)
+			commands.AddService(config, service)
 		}
 	case "remove":
 		if len(os.Args) <= 2 {
 			return nil
 		}
 
-		nameOrUrl := os.Args[2]
+		nameOrURL := os.Args[2]
 
-		service := proxy.NewService(nameOrUrl, nameOrUrl)
+		service := proxy.NewService(nameOrURL, nameOrURL)
 
 		return func() {
 			commands.RemoveService(config, service, *configFile)

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -119,8 +119,7 @@ func AddService(filepath string, service Service) error {
 	file, e := os.OpenFile(filepath, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
 
 	if e != nil {
-		log.Printf("File error: %v\n", e)
-		return e
+		return fmt.Errorf("File error: %v", e)
 	}
 
 	defer file.Close()

--- a/tests/ergo_run_test.go
+++ b/tests/ergo_run_test.go
@@ -146,7 +146,7 @@ func TestAddService(t *testing.T) {
 		}
 		defer c.clean()
 
-		cmd := ergo("add", "-config", c.filePath, "new.service", "http://localhost:8083")
+		cmd := ergo("add", "new.service", "http://localhost:8083", "-config", c.filePath)
 		bs, err := cmd.Output()
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
This fix the problem related to adding new services when using a different ergo file (`-config` flag) it wasn't working.