### PR TITLE
[Chore] Drop support to old go versions due incompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: go
 
 go:
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
+  - 1.11.x
 
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ fmt:
 	echo "${ERROR_COLOR}" && gofmt -l . && \
 	echo "${NO_COLOR}"  && exit 1 || exit 0)
 
-vet:
+vet: tools
 	@(echo "${OK_COLOR}Running vet ...${NO_COLOR}")
 	go vet ./...
 

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,10 @@ start:
 	@go run main.go run
 
 tools:
-	@(go get github.com/golang/lint)
+	@(go get golang.org/x/lint/golint)
+	# @(go get github.com/golang/lint)
 
-fmt:
+fmt: tools
 	@(echo "${OK_COLOR}Running fmt ...${NO_COLOR}")
 	@([ $$(gofmt -l . | wc -l) != 0 ] && \
 	echo "${WARN_COLOR}The following files are not correctly formated:${NO_COLOR}" && \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ clone_folder: c:\gopath\src\github.com\cristianoliveira\ergo
 environment:
   GOPATH: c:\gopath
   DEPTESTBYPASS501: 1
-  GOVERSION: 1.8
+  GOVERSION: 1.11
 
 init:
   - git config --global core.autocrlf input

--- a/commands/setup_test.go
+++ b/commands/setup_test.go
@@ -56,15 +56,15 @@ func TestSetupLinuxGnome(t *testing.T) {
 			CommandExpectToInclude string
 		}{
 			{
-				Title:                  "expect to run with sh",
+				Title: "expect to run with sh",
 				CommandExpectToInclude: "/bin/sh -c",
 			},
 			{
-				Title:                  "expect to set networking mode auto",
+				Title: "expect to set networking mode auto",
 				CommandExpectToInclude: "mode 'auto'",
 			},
 			{
-				Title:                  "expect to set networking url",
+				Title: "expect to set networking url",
 				CommandExpectToInclude: `autoconfig-url '` + config.GetProxyPacURL() + `'`,
 			},
 		}
@@ -91,15 +91,15 @@ func TestSetupLinuxGnome(t *testing.T) {
 			CommandExpectToInclude string
 		}{
 			{
-				Title:                  "expect to run with sh",
+				Title: "expect to run with sh",
 				CommandExpectToInclude: "/bin/sh -c",
 			},
 			{
-				Title:                  "expect to set networking mode none",
+				Title: "expect to set networking mode none",
 				CommandExpectToInclude: "mode 'none'",
 			},
 			{
-				Title:                  "expect to set networking no url",
+				Title: "expect to set networking no url",
 				CommandExpectToInclude: `autoconfig-url ''`,
 			},
 		}
@@ -132,11 +132,11 @@ func TestSetupOSX(t *testing.T) {
 			CommandExpectToInclude string
 		}{
 			{
-				Title:                  "expect to run with sh",
+				Title: "expect to run with sh",
 				CommandExpectToInclude: "/bin/sh -c",
 			},
 			{
-				Title:                  "expect to set networking proxy pac url",
+				Title: "expect to set networking proxy pac url",
 				CommandExpectToInclude: `-setautoproxyurl "Wi-Fi" "` + config.GetProxyPacURL() + `"`,
 			},
 		}
@@ -163,11 +163,11 @@ func TestSetupOSX(t *testing.T) {
 			CommandExpectToInclude string
 		}{
 			{
-				Title:                  "expect to run with sh",
+				Title: "expect to run with sh",
 				CommandExpectToInclude: "/bin/sh -c",
 			},
 			{
-				Title:                  "expect to set networking wi-fi to none",
+				Title: "expect to set networking wi-fi to none",
 				CommandExpectToInclude: `-setautoproxyurl "Wi-Fi" ""`,
 			},
 		}
@@ -200,11 +200,11 @@ func TestSetupWindows(t *testing.T) {
 			CommandExpectToInclude string
 		}{
 			{
-				Title:                  "expect to add a new register",
+				Title: "expect to add a new register",
 				CommandExpectToInclude: "reg add",
 			},
 			{
-				Title:                  "expect to set networking proxy pac url",
+				Title: "expect to set networking proxy pac url",
 				CommandExpectToInclude: `AutoConfigURL /t REG_SZ /d ` + config.GetProxyPacURL(),
 			},
 		}
@@ -231,11 +231,11 @@ func TestSetupWindows(t *testing.T) {
 			CommandExpectToInclude string
 		}{
 			{
-				Title:                  "expect to delete the register",
+				Title: "expect to delete the register",
 				CommandExpectToInclude: "reg delete",
 			},
 			{
-				Title:                  "expect to set networking wi-fi to none",
+				Title: "expect to set networking wi-fi to none",
 				CommandExpectToInclude: "AutoConfigURL /f",
 			},
 		}

--- a/commands/setup_test.go
+++ b/commands/setup_test.go
@@ -56,15 +56,15 @@ func TestSetupLinuxGnome(t *testing.T) {
 			CommandExpectToInclude string
 		}{
 			{
-				Title: "expect to run with sh",
+				Title:                  "expect to run with sh",
 				CommandExpectToInclude: "/bin/sh -c",
 			},
 			{
-				Title: "expect to set networking mode auto",
+				Title:                  "expect to set networking mode auto",
 				CommandExpectToInclude: "mode 'auto'",
 			},
 			{
-				Title: "expect to set networking url",
+				Title:                  "expect to set networking url",
 				CommandExpectToInclude: `autoconfig-url '` + config.GetProxyPacURL() + `'`,
 			},
 		}
@@ -91,15 +91,15 @@ func TestSetupLinuxGnome(t *testing.T) {
 			CommandExpectToInclude string
 		}{
 			{
-				Title: "expect to run with sh",
+				Title:                  "expect to run with sh",
 				CommandExpectToInclude: "/bin/sh -c",
 			},
 			{
-				Title: "expect to set networking mode none",
+				Title:                  "expect to set networking mode none",
 				CommandExpectToInclude: "mode 'none'",
 			},
 			{
-				Title: "expect to set networking no url",
+				Title:                  "expect to set networking no url",
 				CommandExpectToInclude: `autoconfig-url ''`,
 			},
 		}
@@ -132,11 +132,11 @@ func TestSetupOSX(t *testing.T) {
 			CommandExpectToInclude string
 		}{
 			{
-				Title: "expect to run with sh",
+				Title:                  "expect to run with sh",
 				CommandExpectToInclude: "/bin/sh -c",
 			},
 			{
-				Title: "expect to set networking proxy pac url",
+				Title:                  "expect to set networking proxy pac url",
 				CommandExpectToInclude: `-setautoproxyurl "Wi-Fi" "` + config.GetProxyPacURL() + `"`,
 			},
 		}
@@ -163,11 +163,11 @@ func TestSetupOSX(t *testing.T) {
 			CommandExpectToInclude string
 		}{
 			{
-				Title: "expect to run with sh",
+				Title:                  "expect to run with sh",
 				CommandExpectToInclude: "/bin/sh -c",
 			},
 			{
-				Title: "expect to set networking wi-fi to none",
+				Title:                  "expect to set networking wi-fi to none",
 				CommandExpectToInclude: `-setautoproxyurl "Wi-Fi" ""`,
 			},
 		}
@@ -200,11 +200,11 @@ func TestSetupWindows(t *testing.T) {
 			CommandExpectToInclude string
 		}{
 			{
-				Title: "expect to add a new register",
+				Title:                  "expect to add a new register",
 				CommandExpectToInclude: "reg add",
 			},
 			{
-				Title: "expect to set networking proxy pac url",
+				Title:                  "expect to set networking proxy pac url",
 				CommandExpectToInclude: `AutoConfigURL /t REG_SZ /d ` + config.GetProxyPacURL(),
 			},
 		}
@@ -231,11 +231,11 @@ func TestSetupWindows(t *testing.T) {
 			CommandExpectToInclude string
 		}{
 			{
-				Title: "expect to delete the register",
+				Title:                  "expect to delete the register",
 				CommandExpectToInclude: "reg delete",
 			},
 			{
-				Title: "expect to set networking wi-fi to none",
+				Title:                  "expect to set networking wi-fi to none",
 				CommandExpectToInclude: "AutoConfigURL /f",
 			},
 		}


### PR DESCRIPTION
There is an incompatibility in `go fmt` and `golint` (details here: https://github.com/golang/lint/issues/415) between golang versions so we are dropping the ci building and testing for versions below 1.11
