### PR TITLE
feat: allows any pair configuration

### DIFF
--- a/.ergo
+++ b/.ergo
@@ -1,6 +1,9 @@
+mysite  http://localhost:80
+mydomain  http://localhost:8282
 foo http://localhost:3000
 bla http://localhost:5000
 withspaces       http://localhost:8080
 one.domain       http://localhost:8081
 two.domain       http://localhost:8082
 redis://redislocal       redis://localhost:6543
+http://localhost:8082  two.domain

--- a/.ergo
+++ b/.ergo
@@ -1,9 +1,9 @@
-mysite  http://localhost:80
-mydomain  http://localhost:8282
+http://localhost:80 mysite
+http://localhost:8282 mylocalsite
+http://localhost:8082  two.domain
 foo http://localhost:3000
 bla http://localhost:5000
 withspaces       http://localhost:8080
 one.domain       http://localhost:8081
 two.domain       http://localhost:8082
 redis://redislocal       redis://localhost:6543
-http://localhost:8082  two.domain

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ lint: tools
 coverage:
 	@sh ./ci/coverage.sh
 
-test: fmt vet lint
+test:
 	@(go test -v ./...)
 
 test-integration: build

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ In case of errors / it doesn't work, please look at the detailed config session 
 
 #### OS X / Linux
 ```
-echo "ergoproxy http://localhost:3000" > .ergo
+echo "http://localhost:3000 ergoproxy" > .ergo
 ergo run
 ```
 
@@ -112,7 +112,7 @@ Ergo redirects anything ending with `.dev` to the configured url.
 You should not use the default `.dev` domain, we suggest `.test` instead (see [#58](https://github.com/cristianoliveira/ergo/issues/58)) unless your service supports https out of the box and you have already a certificate
 ```
 set ERGO_DOMAIN=.test
-echo ergoproxy http://localhost:3000 > .ergo
+echo "http://localhost:3000 ergoproxy" > .ergo
 ergo list # you shouldn't see any quotas in the output
 ergo run
 ```
@@ -123,7 +123,7 @@ Simple, right? No magic involved.
 
 Do you want to add more services? It's easy, just add more lines in `.ergo`:
 ```
-echo "otherservice http://localhost:5000" >> .ergo
+echo "http://localhost:5000 otherservice" >> .ergo
 ergo list
 ergo run
 ```

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -25,6 +25,22 @@ func TestWhenHasErgoFile(t *testing.T) {
 		}
 	})
 
+	t.Run("It match the service host mysite", func(t *testing.T) {
+		result := config.GetService("mysite.dev")
+
+		if result.Empty() {
+			t.Errorf("Expected result to not be nil")
+		}
+	})
+
+	t.Run("It match the service host mylocalsite", func(t *testing.T) {
+		result := config.GetService("mylocalsite.dev")
+
+		if result.Empty() {
+			t.Errorf("Expected result to not be nil")
+		}
+	})
+
 	t.Run("It match the service host bla.dev", func(t *testing.T) {
 		result := config.GetService("bla.dev")
 
@@ -120,14 +136,15 @@ func TestWhenHasErgoFile(t *testing.T) {
 			tt.Errorf("Expected service to be removed")
 		}
 
-		expected := []byte(`mysite  http://localhost:80
-		mydomain  http://localhost:8282
-		foo http://localhost:3000
-		bla http://localhost:5000
-		withspaces       http://localhost:8080
-		one.domain       http://localhost:8081
-		two.domain       http://localhost:8082
-		redis://redislocal       redis://localhost:6543
+		expected := []byte(`http://localhost:80 mysite
+			http://localhost:8282 mylocalsite
+			http://localhost:8082  two.domain
+			foo http://localhost:3000
+			bla http://localhost:5000
+			withspaces       http://localhost:8080
+			one.domain       http://localhost:8081
+			two.domain       http://localhost:8082
+			redis://redislocal       redis://localhost:6543
 		`)
 
 		if !bytes.Equal(expected, newFileContent) {

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -16,7 +16,7 @@ func TestWhenHasErgoFile(t *testing.T) {
 	}
 
 	t.Run("It loads the services redirections", func(t *testing.T) {
-		expected := 6
+		expected := 8
 		result := len(config.Services)
 
 		if expected != result {
@@ -120,7 +120,9 @@ func TestWhenHasErgoFile(t *testing.T) {
 			tt.Errorf("Expected service to be removed")
 		}
 
-		expected := []byte(`foo http://localhost:3000
+		expected := []byte(`mysite  http://localhost:80
+		mydomain  http://localhost:8282
+		foo http://localhost:3000
 		bla http://localhost:5000
 		withspaces       http://localhost:8080
 		one.domain       http://localhost:8081


### PR DESCRIPTION
  Allows the /etc/hosts pattern of URL:PORT -> name
  or the original ergo pattern of name -> URL:PORT
  but the /etc/hosts pattern has precedence.

(cherry picked from commit 732e34dae69c2d5867b4ae65a6d56a5e13e494ee)