### PR TITLE
feat: allows using wildcards for services

### DIFF
--- a/.ergo
+++ b/.ergo
@@ -7,3 +7,4 @@ withspaces       http://localhost:8080
 one.domain       http://localhost:8081
 two.domain       http://localhost:8082
 redis://redislocal       redis://localhost:6543
+*.wildcard http://localhost:3030

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -102,16 +102,37 @@ var domainPattern *regexp.Regexp
 // GetService gets the service for the given host.
 func (c *Config) GetService(host string) Service {
 	once.Do(func() {
-		domainPattern = regexp.MustCompile(`((\w*\:\/\/)?.+)(` + c.Domain + `)`)
+		domainPattern = regexp.MustCompile(`((.*)\.?)` + c.Domain)
 	})
 
 	parts := domainPattern.FindAllStringSubmatch(host, -1)
 
+	// Example: host = "http://one.domain.dev"
+	// parts = [[one.domain.dev one.domain one.domain]]
 	if len(parts) < 1 {
 		return Service{}
 	}
 
-	return c.Services[parts[0][1]]
+	if len(parts[0]) < 3 {
+		return Service{}
+	}
+
+	domainWithoutTld := parts[0][2]
+
+	// Since finding a wildcard service is expensive, we only do it if
+	// we have at least one wildcard service
+	if c.hasWildcardService {
+		for _, service := range c.Services {
+			if strings.Contains(service.Name, "*") {
+				serviceNameWithoutWildCard := strings.Replace(service.Name, "*", "", -1)
+				if strings.Contains(domainWithoutTld, serviceNameWithoutWildCard) {
+					return service
+				}
+			}
+		}
+	}
+
+	return c.Services[domainWithoutTld]
 }
 
 // GetProxyPacURL returns the correct url for the pac file
@@ -140,6 +161,10 @@ func (c *Config) LoadServices() error {
 	updatedServices := make(map[string]Service)
 	for _, s := range services {
 		if !s.Empty() {
+			// if service name contains wildcard, set hasWildcardService to true
+			if strings.Contains(s.Name, "*") {
+				c.hasWildcardService = true
+			}
 			updatedServices[s.Name] = s
 		}
 	}

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	Verbose    bool
 	Services   map[string]Service
 	ConfigFile string
+
+	hasWildcardService bool
 }
 
 // Defines the name of ergo env variable for configuration.
@@ -106,7 +108,7 @@ func (c *Config) GetService(host string) Service {
 	})
 
 	parts := domainPattern.FindAllStringSubmatch(host, -1)
-
+	fmt.Println("-------------- parts", parts)
 	// Example: host = "http://one.domain.dev"
 	// parts = [[one.domain.dev one.domain one.domain]]
 	if len(parts) < 1 {

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -15,8 +15,27 @@ func TestWhenHasErgoFile(t *testing.T) {
 		t.Fatal("could not load required configuration file for tests")
 	}
 
+	t.Run("Wildcard feature", func(t *testing.T) {
+		cases := []struct {
+			host     string
+			expected bool
+		}{
+			{"foobar.wildcard.dev", true},
+			{"other.wildcard.dev", true},
+		}
+
+		for _, c := range cases {
+			t.Run("It matches the service host with wildcard "+c.host, func(t *testing.T) {
+				result := config.GetService(c.host)
+				if result.Empty() {
+					t.Errorf("Expected result to not be nil")
+				}
+			})
+		}
+	})
+
 	t.Run("It loads the services redirections", func(t *testing.T) {
-		expected := 8
+		expected := 9
 		result := len(config.Services)
 
 		if expected != result {
@@ -73,7 +92,7 @@ func TestWhenHasErgoFile(t *testing.T) {
 		}
 	})
 
-	t.Run("It does match the other protocols than http", func(t *testing.T) {
+	t.Run("It does match other protocols than http", func(t *testing.T) {
 		if result := config.GetService("redis://redislocal.dev"); result.Empty() {
 			t.Errorf("Expected  result to not be nil")
 		}
@@ -145,6 +164,7 @@ func TestWhenHasErgoFile(t *testing.T) {
 			one.domain       http://localhost:8081
 			two.domain       http://localhost:8082
 			redis://redislocal       redis://localhost:6543
+			*.wildcard http://localhost:4000
 		`)
 
 		if !bytes.Equal(expected, newFileContent) {


### PR DESCRIPTION
Usage:
Adds a wildcard service
```
  *.frontend http://localhost:3000
```
Run ergo and then all requests like:
   - http://foo.frontend.dev/
   - http://bar.frontend.dev/
   - http://doesnmatter.frontend.dev/

  Are now redirected to http://localhost:3000

Closes https://github.com/cristianoliveira/ergo/issues/122