### PR TITLE
chore: for windows use tag for release

### DIFF
--- a/.github/workflows/on-release-upload-assets.yml
+++ b/.github/workflows/on-release-upload-assets.yml
@@ -64,7 +64,7 @@ jobs:
       GOOS: windows
       GOARCH: amd64
       TARGET: windows-amd64
-      RELEASE_TAG: v0.3.2
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
 
     runs-on: windows-latest
 


### PR DESCRIPTION
(cherry picked from commit 4a591c453223791e8354ac20df46525b95139f36)